### PR TITLE
broadcom-bluetooth: Fix systemd brcm firmware load service

### DIFF
--- a/recipes-connectivity/bluetooth/files/broadcom-bluetooth/brcm-btfw-load@.service
+++ b/recipes-connectivity/bluetooth/files/broadcom-bluetooth/brcm-btfw-load@.service
@@ -5,8 +5,6 @@ Description=Load Bluetooth firmware
 Type=oneshot
 ExecStartPre=/usr/sbin/rfkill unblock bluetooth
 ExecStart=/bin/bash /usr/bin/brcm-btfw-load.sh %I
-Restart=on-failure
-RestartSec=2
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Previous commit left some incompatible settings in the systemd service.
We remove them now in order to fix this issue:

Restart=on-failure not allowed for Type=oneshot services

Signed-off-by: Florin Sarbu <florin@balena.io>