### PR TITLE
rkwifibt-firmware.bb: Switch fetch protocol to https

### DIFF
--- a/recipes-kernel/rkwifibt-firmware/rkwifibt-firmware.bb
+++ b/recipes-kernel/rkwifibt-firmware/rkwifibt-firmware.bb
@@ -7,7 +7,7 @@ LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://NOTICE;md5=9645f39e9db895a4aa6e02cb57294595"
 
 SRCREV = "e927d31cd7f72a854a56116b24cae4bdf057d859"
-SRC_URI = "git://github.com/radxa/rkwifibt.git"
+SRC_URI = "git://github.com/radxa/rkwifibt.git;protocol=https"
 
 S = "${WORKDIR}/git"
 


### PR DESCRIPTION
We do this to avoid the following error when fetching the
kernel source code:

The unauthenticated git protocol on port 9418 is no longer supported.
Please see
https://github.blog/2021-09-01-improving-git-protocol-security-github/
for more information.

Signed-off-by: Florin Sarbu <florin@balena.io>