### PR TITLE
rkwifibt-firmware: Use AW-NB197 bluetooth firmware for AP6212 based c…

### DIFF
--- a/recipes-kernel/rkwifibt-firmware/rkwifibt-firmware.bb
+++ b/recipes-kernel/rkwifibt-firmware/rkwifibt-firmware.bb
@@ -15,7 +15,9 @@ inherit allarch deploy
 
 do_install() {
 	install -d ${D}/system/etc/firmware/
-	install -m 0644 ${S}/firmware/broadcom/AP6212A1/*/* \
+	install -m 0644 ${S}/firmware/broadcom/AW-NB197/bt/BCM4343A1_001.002.009.1008.1024.hcd
+		${D}/system/etc/firmware/bcm43438a1.hcd
+	install -m 0644 ${S}/firmware/broadcom/AP6212A1/wifi/* \
 		-t ${D}/system/etc/firmware/
 	install -m 0644 ${S}/firmware/broadcom/AP6236/*/* \
 		-t ${D}/system/etc/firmware/


### PR DESCRIPTION
…hips

Since the AW-NB197 bluetooth firmware has just been updated let's switch
to using it for all the AP6212 based chips.

Signed-off-by: Florin Sarbu <florin@balena.io>