### PR TITLE
recipes-bsp: u-boot: radxa cm3 io: Delete references to removed files

### DIFF
--- a/recipes-bsp/u-boot/u-boot-radxa-cm3-io.bb
+++ b/recipes-bsp/u-boot/u-boot-radxa-cm3-io.bb
@@ -12,8 +12,6 @@ SRC_URI = " \
 	file://${MACHINE}/0001-to-avoid-warnings-when-compiling-with-GCC-8.1.patch \
 	file://${MACHINE}/boot.cmd \
 	file://${MACHINE}/uEnv.txt \
-	file://${MACHINE}/idbloader.img \
-	file://${MACHINE}/u-boot.itb \
 "
 
 SRCREV = "693c4cd017e57a6af8e471494be5e8780c041b08"


### PR DESCRIPTION
The prebuilt idbloader.img and u-boot.itb files have been removed so let's
also delete the references to them.

Signed-off-by: Florin Sarbu <florin@balena.io>