### PR TITLE
radxa-zero-s905y2.conf: Add AP6212 bluetooth and wifi firmware

### DIFF
--- a/conf/machine/radxa-zero-s905y2.conf
+++ b/conf/machine/radxa-zero-s905y2.conf
@@ -19,6 +19,8 @@ KERNEL_DEVICETREE = "amlogic/meson-g12a-radxa-zero.dtb"
 UBOOT_MACHINE = "radxa-zero_defconfig"
 
 MACHINE_ESSENTIAL_EXTRA_RRECOMMENDS += "\
+    rkwifibt-firmware-ap6212a1-bt \
+    rkwifibt-firmware-ap6212a1-wifi \
     rkwifibt-firmware-ap6256-wifi \
     rkwifibt-firmware-ap6256-bt \
 "


### PR DESCRIPTION
The Radxa Zero comes in various combinations with regards to the BT / WiFi chipset
and one of these variants contains the AP6212 chipset.

Signed-off-by: Florin Sarbu <florin@balena.io>