### PR TITLE
Fix build for custom radxa-cm3-io-rk3566 based devices

### DIFF
--- a/recipes-bsp/u-boot/u-boot-radxa-cm3-io.bb
+++ b/recipes-bsp/u-boot/u-boot-radxa-cm3-io.bb
@@ -10,12 +10,12 @@ SRC_URI = " \
 	file://0001-Use-local-command.h-file-instead-of-system-file.patch \
 	file://0002-Suppress-maybe-uninitialized-warning.patch \
 	file://0003_Fix-failed_to_create_atf.patch \
-	file://${MACHINE}/0001-to-avoid-warnings-when-compiling-with-GCC-8.1.patch \
-	file://${MACHINE}/0002-fs-ext4-cache-extent-data.patch \
-	file://${MACHINE}/0003-fs-ext4-Fix-alignment-of-cache-buffers.patch \
-	file://${MACHINE}/0004-mkimage-Fix-header-generation-of-boot.scr.patch \
-	file://${MACHINE}/boot.cmd \
-	file://${MACHINE}/uEnv.txt \
+	file://0001-to-avoid-warnings-when-compiling-with-GCC-8.1.patch \
+	file://0002-fs-ext4-cache-extent-data.patch \
+	file://0003-fs-ext4-Fix-alignment-of-cache-buffers.patch \
+	file://0004-mkimage-Fix-header-generation-of-boot.scr.patch \
+	file://boot.cmd \
+	file://uEnv.txt \
 "
 
 SRCREV = "693c4cd017e57a6af8e471494be5e8780c041b08"

--- a/recipes-bsp/u-boot/u-boot-rockpi.inc
+++ b/recipes-bsp/u-boot/u-boot-rockpi.inc
@@ -4,7 +4,7 @@ HOMEPAGE = "https://github.com/radxa/u-boot"
 LICENSE = "GPLv2+"
 COMPATIBLE_MACHINE = "(px30|rk3036|rk3066|rk3188|rk3288|rk3328|rk3399|rk3308|rk3399pro|rk3566|s905y2)"
 SECTION = "bootloaders"
-DEPENDS = "dtc-native bc-native swig-native bison-native coreutils-native"
+DEPENDS = "dtc-native bc-native swig-native bison-native coreutils-native radxa-binary-loader"
 
 S = "${WORKDIR}/git"
 

--- a/recipes-kernel/linux/linux-radxa-cm3-io_4.19.bb
+++ b/recipes-kernel/linux/linux-radxa-cm3-io_4.19.bb
@@ -40,5 +40,5 @@ do_compile_append() {
 
 do_deploy_append() {
 	install -d ${DEPLOYDIR}/overlays
-	install -m 644 ${WORKDIR}/linux-radxa_cm3_io_rk3566-standard-build/arch/arm64/boot/dts/rockchip/overlay/* ${DEPLOYDIR}/overlays
+	install -m 644 ${B}/arch/arm64/boot/dts/rockchip/overlay/* ${DEPLOYDIR}/overlays
 }


### PR DESCRIPTION
This fixes build errors while building for customised Yocto machines, based on radxa-cm3-io-rk3566.